### PR TITLE
Replaces the Hyperlink color when cursor is hovered to a better viewa…

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -256,7 +256,9 @@
         <div class="container has-text-centered pt-4 ">
             <h2 class="title is-2 is-spaced has-text-weight-bold has-text-white ">{{ .Params.jtc.title}}</h2>
             <h4 class="subtitle has-text-white "> {{ .Params.jtc.subtitle}}
-                <a href="mailto:{{ .Params.jtc.mailing }} ">
+                <a href="mailto:{{ .Params.jtc.mailing }} " 
+                    onMouseOver="this.style.color='#40b9ff'"
+                    onMouseOut="this.style.color='#3273dc'" >
                     {{ .Params.jtc.mailing }}
                 </a>
             </h4>


### PR DESCRIPTION
As mentioned in #3 , the color of the hyperlink when hovered wasn't very useful in that area

So I tried to add an inline change to the CSS lines to change the color of the Hyperlink when the [cursor is over the link](https://github.com/cr2007/hwtech.club/blob/54fd88c3cebaa25ca4345fbcb1558c2facac1dd7/layouts/_default/index.html#L260), and when the [cursor is out of it](https://github.com/cr2007/hwtech.club/blob/54fd88c3cebaa25ca4345fbcb1558c2facac1dd7/layouts/_default/index.html#L261) in the following manner:
```html
<a href="mailto:{{ .Params.jtc.mailing }} "
   onMouseOver="this.style.color='#40b9ff'"
   onMouseOut="this.style.color='#3273dc'">
        {{ .Params.jtc.mailing }}
</a>
```

This change overrides Bulma's standards of `a:hover` for this specific case to a more easily readable one.
Related Issue: Resolves the issue with #3 

Referance: [StackOverflow](https://stackoverflow.com/questions/1033156/how-to-write-ahover-in-inline-css#:~:text=526-,You%20can%20get%20the,-same%20effect%20by)